### PR TITLE
refactor: muda nome da coluna para 'cidade polo mais próxima'

### DIFF
--- a/src/components/EscolaRanqueModal/index.tsx
+++ b/src/components/EscolaRanqueModal/index.tsx
@@ -118,7 +118,8 @@ const ModalRanqueEscola: React.FC<ModalProps> = ({ escolaId, onClose, onCreateAc
                     </div>
                     <hr />
                     <div className='d-flex flex-column '>
-                        <Label><strong>Superintendência</strong></Label>
+                        {/* <Label><strong>Superintendência</strong></Label> */}
+                        <Label><strong>Cidade polo mais próxima</strong></Label>
                         <Label>Distância: {escolaSelecionada.distanciaSuperintendencia?.toFixed(2)} Km</Label>
                         <Label>Endereço: {superintendenciaSelecionada?.endereco}</Label>
                         <Label>Cep: {superintendenciaSelecionada?.cep}</Label>

--- a/src/pages/Ranque/index.tsx
+++ b/src/pages/Ranque/index.tsx
@@ -37,7 +37,7 @@ function Ranque() {
   const paginas = [{ nome: "Logout", link: "/login" }];
   const [loading, setLoading] = useState(true);
   const [escolas, setEscolas] = useState<ListaPaginada<EscolaRanqueData> | null>(null);
-  const colunas = ['Posição', 'Pontuação', 'Escola', 'Etapas de Ensino', 'UF', 'Município', 'UF Superintendência', 'Custo Logístico'];
+  const colunas = ['Posição', 'Pontuação', 'Escola', 'Etapas de Ensino', 'UF', 'Município', 'Cidade polo mais próxima', 'Custo Logístico'];
 
   const [paginacao, setPaginacao] = useState({pagina: 1, tamanhoPagina: 10,});
   const [notificationApi, notificationContextHandler] = notification.useNotification();


### PR DESCRIPTION
## Troca texto para "Cidade polo mais próxima"

Resolves https://github.com/fga-eps-mds/2023.2-Dnit-DOC/issues/108.


![Screenshot from 2023-11-25 02-24-37](https://github.com/fga-eps-mds/2023.2-Dnit-Front/assets/37981839/7f07911f-5f07-49c0-b6b8-58d7a63aa850)
Mudança no nome da coluna na tabela de ranque.

<br>

![Screenshot from 2023-11-25 02-24-59](https://github.com/fga-eps-mds/2023.2-Dnit-Front/assets/37981839/81f6dcf8-fdc5-44ce-91e6-c7fa58fcf240)
Mudança no modal de detalhes da escola.
